### PR TITLE
Drop Jars at feet if no inventory room, or add to inventory

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/souljars/JarsListener.java
+++ b/src/main/java/io/github/thebusybiscuit/souljars/JarsListener.java
@@ -86,7 +86,15 @@ public class JarsListener implements Listener {
 
             if (emptyJar.isItem(stack)) {
                 ItemUtils.consumeItem(stack, false);
-                killer.getWorld().dropItemNaturally(e.getEntity().getLocation(), jar.getItem().clone());
+                int freeSlot = killer.getInventory().firstEmpty();
+                if (freeSlot != -1) {
+                    // There is a free inventory slot, use it
+                    killer.getInventory().setItem(freeSlot, jar.getItem().clone());
+                }
+                else {
+                    // No free space, drop the jar at the killer's feet
+                    killer.getWorld().dropItemNaturally(killer.getLocation(), jar.getItem().clone());
+                }
                 return;
             }
         }


### PR DESCRIPTION
If there is a free inventory slot, add the jar to the inventory, otherwise drop it at the Killer's feet instead of the mob's position.

The problem is that in grinder's, or with mobs that can pick up items, a soul jar can get "lost" in a regular hopper or picked up by the mob requiring the mob to be killed to get the jar back. This prevents the kill from counting to the jar's soul count.

It makes more sense to give it back to the user in a much more streamlined way such as this in my opinion.